### PR TITLE
fix case when response contains empty list

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -46,7 +46,11 @@ process_response <- function(x, y, z, w){
     if (w %in% c("stats",'images','geo','sequencinglabs','depository')) out <- out[[1]]
     trynames <- tryCatch(as.numeric(names(out)), warning = function(w) w)
     if (!is(trynames, "simpleWarning")) names(out) <- NULL
-    out[vapply(out, length, numeric(1)) < 1] <- 0
+    if (any(vapply(out, function(x) is.list(x) && length(x) > 0, logical(1)))) {
+        out <- lapply(out, function(x) Filter(length, x))
+    } else {
+        out <- Filter(length, out)
+    }
     if (!is.null(names(out))) {
       df <- data.frame(out, stringsAsFactors = FALSE)
     } else {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -46,8 +46,9 @@ process_response <- function(x, y, z, w){
     if (w %in% c("stats",'images','geo','sequencinglabs','depository')) out <- out[[1]]
     trynames <- tryCatch(as.numeric(names(out)), warning = function(w) w)
     if (!is(trynames, "simpleWarning")) names(out) <- NULL
-    if (!is.null(names(out))) { 
-      df <- data.frame(out, stringsAsFactors = FALSE) 
+    out[vapply(out, length, numeric(1)) < 1] <- 0
+    if (!is.null(names(out))) {
+      df <- data.frame(out, stringsAsFactors = FALSE)
     } else {
       df <- do.call(rbind.fill, lapply(out, data.frame, stringsAsFactors = FALSE))
     }

--- a/tests/testthat/test-bold_tax_id.R
+++ b/tests/testthat/test-bold_tax_id.R
@@ -30,22 +30,30 @@ test_that("bold_tax_id dataTypes param works as expected", {
   bb <- bold_tax_id(88899, dataTypes = "stats")
   dd <- bold_tax_id(88899, dataTypes = "geo")
   ee <- bold_tax_id(88899, dataTypes = "sequencinglabs")
+  ff <- bold_tax_id(321215, dataTypes = "stats")       # no public marker sequences
+  gg <- bold_tax_id(321215, dataTypes = "basic,stats") # no public marker sequences
 
   expect_is(aa, "data.frame")
   expect_is(bb, "data.frame")
   expect_is(dd, "data.frame")
   expect_is(ee, "data.frame")
+  expect_is(ff, "data.frame")
+  expect_is(gg, "data.frame")
 
   expect_equal(NROW(aa), 1)
   expect_equal(NROW(bb), 1)
   expect_equal(NROW(dd), 1)
   expect_equal(NROW(ee), 1)
+  expect_equal(NROW(ff), 1)
+  expect_equal(NROW(gg), 1)
 
   expect_named(dd, c('input','Brazil','Mexico','Panama','Guatemala','Peru','Bolivia','Ecuador'))
 
   expect_gt(NCOL(bb), NCOL(aa))
   expect_gt(NCOL(ee), NCOL(aa))
   expect_gt(NCOL(bb), NCOL(ee))
+  expect_gt(NCOL(ff), NCOL(aa))
+  expect_gt(NCOL(gg), NCOL(ff))
 })
 
 test_that("includeTree param works as expected", {


### PR DESCRIPTION
When doing:

```r
bold_tax_id(321215, dataTypes="stats")
```

I get

```r
Error in (function (..., row.names = NULL, check.rows = FALSE, check.names = TRUE,  : 
  arguments imply differing number of rows: 1, 0
```

Looking at the response from the API, I saw:

```r
Browse[2]> out
$publicspecies
[1] 0

$publicbins
[1] 0

$publicmarkersequences
list()

$publicrecords
[1] 0

$publicsubspecies
[1] 0

$specimenrecords
[1] "15"

$sequencedspecimens
[1] "54"

$barcodespecimens
[1] "5"

$species
[1] "1"

$barcodespecies
[1] "1"
```

The proposed change in the code tries to deal with these situations where one the slots contains an empty list. I'm not entirely sure it's the best approach as I'm not too familiar with the other kinds of output this API provide, but all the tests pass.

