### PR TITLE
Fixes to output of bold_seq() and fasta_split()

### DIFF
--- a/R/bold_seq.R
+++ b/R/bold_seq.R
@@ -3,7 +3,6 @@
 #' Get sequences for a taxonomic name, id, bin, container, institution, 
 #' researcher, geographic, place, or gene.
 #'
-#' @importFrom stringr str_split
 #' @export
 #' @template args
 #' @template otherargs
@@ -15,7 +14,7 @@
 #' @param marker (character) Returns all records containing matching 
 #' marker codes.
 #'
-#' @return A data.frame with each element as row and 5 columns for processid, identification, 
+#' @return A data frame with each element as row and 5 columns for processid, identification, 
 #' marker, accession, and sequence.
 #' 
 #' @examples \dontrun{

--- a/R/bold_seq.R
+++ b/R/bold_seq.R
@@ -54,11 +54,11 @@ bold_seq <- function(taxon = NULL, ids = NULL, bin = NULL, container = NULL,
                   geo = geo,
                   marker = marker)
   paramsNames = names(params)
-  params = params[!vapply(params, is.null, F)]
+  params = params[vapply(params, function(x){is.character(x)&&x!=""}, F)]
   if(length(params)==0){
-    stop(paste0("You must provide a non-empty value to at least one of\n", paste(paramsNames, collapse = "\n")))
+    stop(paste0("You must provide a non-empty value to at least one of\n  ", paste(paramsNames, collapse = "\n  ")))
   }
-  params <- vapply(params[vapply(params, is.character, F)], paste, collapse = "|", "")
+  params <- vapply(params, paste, collapse = "|", "")
   out <- b_GET(paste0(bbase(), 'API_Public/sequence'), params, ...)
   if (response) { 
     out 

--- a/R/bold_seq.R
+++ b/R/bold_seq.R
@@ -3,7 +3,7 @@
 #' Get sequences for a taxonomic name, id, bin, container, institution, 
 #' researcher, geographic, place, or gene.
 #'
-#' @importFrom stringr str_replace_all str_replace str_split
+#' @importFrom stringr str_split
 #' @export
 #' @template args
 #' @template otherargs
@@ -15,8 +15,8 @@
 #' @param marker (character) Returns all records containing matching 
 #' marker codes.
 #'
-#' @return A list with each element of length 4 with slots for id, name, 
-#' gene, and sequence.
+#' @return A data.frame with each element as row and 5 columns for processid, identification, 
+#' marker, accession, and sequence.
 #' 
 #' @examples \dontrun{
 #' res <- bold_seq(taxon='Coelioxys')
@@ -46,22 +46,21 @@
 bold_seq <- function(taxon = NULL, ids = NULL, bin = NULL, container = NULL, 
   institutions = NULL, researchers = NULL, geo = NULL, marker = NULL, 
   response=FALSE, ...) {
-  
-  args <- bc(
-    list(
-      taxon = pipeornull(taxon), geo = pipeornull(geo), 
-      ids = pipeornull(ids), bin = pipeornull(bin), 
-      container = pipeornull(container), 
-      institutions = pipeornull(institutions),
-      researchers = pipeornull(researchers), marker = pipeornull(marker)
-    )
-  )
-  check_args_given_nonempty(
-    args, 
-    c('taxon','ids','bin','container','institutions','researchers',
-      'geo','marker')
-  )
-  out <- b_GET(paste0(bbase(), 'API_Public/sequence'), args, ...)
+  params <- list(taxon = taxon,
+                  ids = ids,
+                  bin = bin,
+                  container = container,
+                  institutions = institutions,
+                  researchers = researchers,
+                  geo = geo,
+                  marker = marker)
+  paramsNames = names(params)
+  params = params[!vapply(params, is.null, F)]
+  if(length(params)==0){
+    stop(paste0("You must provide a non-empty value to at least one of\n", paste(paramsNames, collapse = "\n")))
+  }
+  params <- vapply(params[vapply(params, is.character, F)], paste, collapse = "|", "")
+  out <- b_GET(paste0(bbase(), 'API_Public/sequence'), params, ...)
   if (response) { 
     out 
   } else {

--- a/R/bold_seq.R
+++ b/R/bold_seq.R
@@ -72,6 +72,6 @@ bold_seq <- function(taxon = NULL, ids = NULL, bin = NULL, container = NULL,
       tt <- strdrop(str = tt, pattern = "Fatal+")[[1]]
     }
     res <- strsplit(tt, ">")[[1]][-1]
-    lapply(res, split_fasta)
+    split_fasta(res)
   }
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,8 +4,8 @@ bc <- function(x) Filter(Negate(is.null), x)
 
 split_fasta <- function(x){
   tmp = as.data.frame(stringr::str_split_fixed(x, "\\\r\\\n", n = 3))
-  df = cbind(stringr::str_split_fixed(tmp[,1], "\\|", n = 4), tmp[,2])
-  colnames(df) = c("processid", "identification", "marker", "accession","sequence")
+  df = cbind(as.data.frame(stringr::str_split_fixed(tmp[,1], "\\|", n = 4)), tmp[,2])
+  colnames(df) = c("processid", "identification", "marker", "accession", "sequence")
   df[df==""] = NA
   return(df)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,9 +3,9 @@ bbase <- function() 'https://v4.boldsystems.org/index.php/'
 bc <- function(x) Filter(Negate(is.null), x)
 
 split_fasta <- function(x){
-  tmp <- as.data.frame(stringr::str_split_fixed(gsub("\\\r\\\n", "|",x), "\\|", n = 6))[-6]
-  colnames(tmp) = c("processid", "identification", "marker", "accession","sequence")
-  return(tmp)
+  df <- as.data.frame(str_split_fixed(x, "\\\r\\\n|\\|", n = 6))[-6]
+  colnames(df) = c("processid", "identification", "marker", "accession","sequence")
+  return(df)
 }
 
 pipeornull <- function(x){

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,8 +3,10 @@ bbase <- function() 'https://v4.boldsystems.org/index.php/'
 bc <- function(x) Filter(Negate(is.null), x)
 
 split_fasta <- function(x){
-  df <- as.data.frame(str_split_fixed(x, "\\\r\\\n|\\|", n = 6))[-6]
+  tmp = as.data.frame(stringr::str_split_fixed(x, "\\\r\\\n", n = 3))
+  df = cbind(stringr::str_split_fixed(tmp[,1], "\\|", n = 4), tmp[,2])
   colnames(df) = c("processid", "identification", "marker", "accession","sequence")
+  df[df==""] = NA
   return(df)
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,12 +3,9 @@ bbase <- function() 'https://v4.boldsystems.org/index.php/'
 bc <- function(x) Filter(Negate(is.null), x)
 
 split_fasta <- function(x){
-  temp <- paste(">", x, sep = "")
-  seq <- str_replace_all(str_split(str_replace(temp[[1]], "\n", "<<<"), 
-                                   "<<<")[[1]][[2]], "\n", "")
-  seq <- gsub("\\\r|\\\n", "", seq)
-  stuff <- str_split(x, "\\|")[[1]][c(1:3)]
-  list(id = stuff[1], name = stuff[2], gene = stuff[1], sequence = seq)
+  tmp <- as.data.frame(stringr::str_split_fixed(gsub("\\\r\\\n", "|",x), "\\|", n = 6))[-6]
+  colnames(tmp) = c("processid", "identification", "marker", "accession","sequence")
+  return(tmp)
 }
 
 pipeornull <- function(x){

--- a/README.Rmd
+++ b/README.Rmd
@@ -72,10 +72,11 @@ library("bold")
 
 ### Search for sequence data only
 
-Default is to get a list back
+By default you download `fasta` file, which is given back to you as a `data.frame`
 
 ```{r}
-bold_seq(taxon='Coelioxys')[[1]]
+res <- bold_seq(taxon='Coelioxys')
+head(res)
 ```
 
 You can optionally get back the `crul` response object

--- a/tests/testthat/test-bold_identify_parents.R
+++ b/tests/testthat/test-bold_identify_parents.R
@@ -48,7 +48,7 @@ test_that("bold_identify_parents: catch wrong type param inputs", {
   
   vcr::use_cassette("bold_identify_parents_wrong_type", {
     w <- bold_seq(ids = "COLNO026-09")
-    ww <- bold_identify(w[[1]]$sequence)
+    ww <- bold_identify(w$sequence)
   })
 
   expect_error(bold_identify_parents(ww[[1]][1, ], tax_rank = 5),

--- a/tests/testthat/test-bold_seq.R
+++ b/tests/testthat/test-bold_seq.R
@@ -6,17 +6,24 @@ vcr::use_cassette("bold_seq_works_taxon", {
     skip_on_cran()
   
     a <- bold_seq(taxon='Coelioxys')
-    expect_is(a, "list")
-    expect_is(a[[1]], "list")
-    expect_is(a[[1]]$id, "character")
-    expect_is(a[[1]]$sequence, "character")
+    expect_is(a, "data.frame")
+    expect_is(a$processid, "character")
+    expect_is(a$identification, "character")
+    expect_is(a$marker, "character")
+    expect_is(a$accession, "character")
+    expect_is(a$sequence, "character")
   })
 })
 
 vcr::use_cassette("bold_seq_works_bin", {
   test_that("bold_seq returns the correct dimensions/classes", {
     b <- bold_seq(bin='BOLD:AAA5125')
-    expect_is(b, "list")
+    expect_is(b, "data.frame")
+    expect_is(b$processid, "character")
+    expect_is(b$identification, "character")
+    expect_is(b$marker, "character")
+    expect_is(b$accession, "character")
+    expect_is(b$sequence, "character")
   })
 })
 


### PR DESCRIPTION
## Description
Fixed the output od bold_seq() so it returns the gene marker instead of the id and keeps the accession number when present.
Output is now a data.frame and the names of the columns match the bold API documentation. The @return in the bold_seq documentation was updated accordingly.
Some code in split_fasta() seemed to be redundant and was removed/replaced.
I tried optimizing both functions for time and memory usage.
The test files for test-bold_seq.R, test-bold_identify_parent.R and README.Rmd files were updated to match the new output.


## Related Issue
#79

## Example
```r
library(bold)
res <- bold_seq(taxon='Coelioxys')
head(res)
```
```
     processid      identification        marker   accession 
[1,] "ACUFI1126-13" "Coelioxys rufescens" "COI-5P" "MZ607001"
[2,] "ACUFI1497-14" "Coelioxys elongata"  "COI-5P" "MZ627630"
[3,] "BBHYA529-12"  "Coelioxys"           "COI-5P" NA        
[4,] "BEECA511-06"  "Coelioxys modesta"   "COI-5P" NA        
[5,] "BEECA530-06"  "Coelioxys alternata" "COI-5P" NA        
[6,] "BEECA776-07"  "Coelioxys vigilans"  "COI-5P" NA               
     sequence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
[1,] "TATTATATATATAATTTTTGCAATTTGATCAGGAATAATTGGATCTTCACTAAGAATAATTATTCGAATAGAATTAAGAATCCCAGGATCATGAATTAATAATGATATAATTTATAACTCTTTTATTACAGCTCATGCATTTTTAATAATTTTTTTTTTAGTTATACCTTTTTTAATTGGAGGATTTGGAAATTGATTAGCTCCTTTAATATTAGGAGCCCCAGATATAGCATTCCCTCGAATAAATAATATTAGATTTTGATTATTACCTCCTTCTTTATTAATATTATTAACTAGTAATTTAATTAATCCTAGACCAGGAACAGGATGAACAATTTATCCTCCTTTATCTTTATACAATTATCATCCTTCACCATCAGTAGATTTAGCAATTTTTTCTTTACATTTATCAGGAATATCATCTATTATTGGTTCAATAAATTTTATTGTAACAATTTTATTAATAAAAAATTATTCAATAAATTATAATCAAATACCTTTATTCCCATGATCAATTTTAATCACTACAATTTTATTATTATTATCTTTACCTGTTTTAGCAGGAGCAATTACAATATTATTATTTGATCGAAATTTAAATTCATCCTTTTTTGGCCCCTTAGGAGGAGGAGNTCCAATTTTATATCAACATTTATTT"   
[2,] "-------------------------------------ATTGGATCCTCATTAAGAATAATTATTCGAATAGAATTAAGAATTCCAGGATCTTGGATTAATAACGATCAAATTTATAACTCTTTTATTACAGCTCATGCATTTTTAATAATTTTTTTTTTAGTAATACCATTTTTAATTGGAGGATTTGGTAATTGATTAGCACCATTAATATTAGGAGCTCCTGATATAGCTTTCCCACGAATAAATAATATCAGATTTTGATTATTACCTCCTTCATTATTAATATTATTATCTAGTAATTTAATTTCACCTANACCAGGAACAGGATGAACAGTTTATCCACCATTATCATTATATACATATCATCCTTCCCCATCAGTTGATTTAGCAATTTTTTCTTTACATTTATCAGGAATTTCTTCTATTATCGGATCAATAAATTTTATTGTAACAATTTTAATAATA---AAAAATTATTCAATAAATTATAATCAAATACCTTTATTTCCATGATCAATTTTAATTACTACAATTTTATTATTATTATCATTACCTGTATTAGCAGGAGCTATTACAATATTATTATTTGATCGTAATTTAAATTCATCATTTTTTGACCCAATAGGAGGAGGAGATCCTATTTTATATCAACATTTATTT"
[3,] "AATAATATATATAATTTTTGCTATATGATCAGGAATGATTGGATCATCATTAAGAATAATTATTCGTATAGAATTAAGAACACCAGGTTCTTGAATTAATAATGATCAAATTTATAATTCATTTATTACAGCTCATGCATTTTTAATAATTTTTTTCCTAGTAATACCATTTTTAATTGGTGGATTTGGAAATTGATTAGTTCCATTAATAATTGGAGCTCCTGATATAGCATTCCCACGAATAAATAATATTAGATTTTGATTGTTACCTCCTTCACTATTAATATTACTTATAAGAAACTTCATTTCACCTAGACCAGGAACAGGATGAACTGTATATCCCCCATTATCATCATATAATTTTCATCCATCACCTTCAGTAGATATAGCTATTTTTTCCTTACATTTATCTGGTATTTCTTCAATTATTGGATCAATAAATTTTATTGTAACAATTTTAATAATAAAAAATTACTCATTAAATTATAGTAAAATATCTTTATTTCCTTGATCTATTTTAATTACAACAATTCTTTTATTATTATCTTTACCTGTTTTAGCAGGAGCAATTACAATATTACTTTTTGATCGTAATTTAAATACTTCATTTTTTGATCCAATAGGAGGAGGAGACCCAATTTTATACCAACATTTATTT"   
[4,] "-------------------------------GGTATAATTGGATCATCTTTAAGAATAATTATTCGCATAGAATTAAGAATCCCGGGTTCTTGAATTAACAATGATCAAATTTATAATTCTTTTATTACAGCTCATGCCTTTTTAATAATTTTTTTCCTAGTAATACCTTTTTTAATTGGTGGATTTGGTAATTGATTAGTACCTTTAATAATTGGAGCCCCAGATATAGCCTTCCCACGAATAAATAATATTAGATTTTGACTTTTACCCCCTTCTTTATTACTTTTATTATCAAGAAATTTAATTAATCCCAGACCTGGTACTGGATGAACAGTTTACCCACCTTTATCTTTATATAATTTTCATCCTTCTCCTTCAGTTGATTTAGCTATTTTTTCATTACATTTATCTGGAATCTCATCTATTATTGGATCAATAAATTTTATTGTTACTATTTTAATAATAAAAAATTTTTCATTAAATTATAGACAAATACCCTTATTCCCATGATCAGTTATAATTACTACAATCTTATTATTATTATCCTTACCAGTATTAGCAGGAGCAATTACAATATTATTATTTGATCGAAATTTTAATTCTTCATTTTTTGACCCAATAGGAGGAGGAGAC------------------------"   
[5,] "----------------------------------------GGATCATCATTAAGAATAATTATTCGTATAGAATTAAGAACTCCAGGTTCATGAATCAATAATGATCAAATTTATAATTCATTTATTACAGCCCATGCATTTTTAATAATCTTTTTCCTAGTAATACCATTTTTAATTGGTGGTTTTGGAAATTGATTAGTTCCTTTAATAATTGGAGCTCCTGATATAGCATTCCCACGAATAAATAATATTAGATTTTGATTATTACCTCCTTCACTGTTAATATTACTTATAAGAAATTTCATCTCACCTAGACCAGGAACAGGATGAACTGTATATCCTCCATTATCATTATACAATTTTCATCCTTCACCTTCAGTAGATATAGCTATTTTTTCCCTACATTTATCTGGAATTTCTTCAATTATTGGATCAATAAACTTTATTGTAACAATTTTAATAATAAAAAATTATTCATTAAATTATAGTAAAATATCTTTATTCCCATGATCTATTTTAATTACAACAATTCTTTTATTATTATCTTTACCTGTTTTAGCAGGAGCAATTACAATATTATTATTTGATCGTAATATAAATACTTCATTTTTTGACCCAATAGGAGGAGGAGAC------------------------"   
[6,] "CATCCTATATATAATTTTTGCCATATGGTCAGGAATAATTGGATCTTCATTAAGAATAATTATTCGTATAGAATTAAGAATCCCAGGCTCTTGGATTAGTAATGACCAAATTTATAATTCTTTTATTACTGCTCATGCATTTTTAATAATTTTTTTTTTAGTTATACCTTTCCTTATTGGAGGGTTTGGAAATTGATTAGTACCCTTAATAATTGGAGCTCCCGACATAGCATTCCCACGTATAAATAATGTTAGATTTTGATTATTACCACCATCTTTATTACTATTACTATCGAGAAATTTAATTAACCCAAGTCCTGGTACAGGATGAACAGTGTATCCCCCATTATCTTCTTATACATTTCATCCATCCCCATCAGTTGACTTAGCAATTTTTTCATTACATTTATCGGGTATTTCTTCTATTATTGGATCAATAAATTTTATTGTTACAATTTTAATAATAAAAAATTATTCTCTTAATTATAGACAAATACCATTATTCCCATGATCAGTTTTAGTCACTACAGTTTTATTACTTTTATCTTTACCAGTATTAGCTGGAGCAATCACAATATTATTATTTGATCGAAATTTAAATACATCATTTTTTGACCCAATAGGAGGAGGTGAC------------------------"
```
## Tests
```r
==> devtools::test()

i Loading bold
i Testing bold
v |  OK F W S | Context
v |  14       | bold_filter [1.6 s]                        
v |  13       | bold_identify [0.9 s]                      
v |  16       | bold_identify_parents [4.3 s]              
v |  18       | bold_seq [0.4 s]                           
v |  13       | bold_seqspec [2.6 s]                       
v |   7       | bold_specimens [1.6 s]                     
v |  13       | bold_stats [0.3 s]                         
v |  25       | bold_tax_id [0.8 s]                        
v |   9       | bold_tax_name [0.4 s]                      

== Results ================================================
Duration: 12.8 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 128 ]
```