### PR TITLE
Changed encoding function in bold_seqspec

### DIFF
--- a/R/bold_seqspec.R
+++ b/R/bold_seqspec.R
@@ -62,7 +62,7 @@ bold_seqspec <- function(taxon = NULL, ids = NULL, bin = NULL, container = NULL,
   } else {
     tt <- paste0(rawToChar(out$content, multiple = TRUE), collapse = "")
     if (tt == "") return(NA)
-    Encoding(tt) <- "UTF-8"
+    tt <- enc2utf8(tt)
     if (grepl("Fatal error", tt)) {
       stop("BOLD servers returned an error - we're not sure what happened\n ",
         "try a smaller query - or open an issue and we'll try to help")


### PR DESCRIPTION
## Description
Changed encoding function in bold_seqspec from `Encoding()` to `enc2utf8()`.

## Related Issue
Fixes bug in issue #81 
