### PR TITLE
fix for global variables note

### DIFF
--- a/R/bold_filter.R
+++ b/R/bold_filter.R
@@ -1,3 +1,6 @@
+if (getRversion() >= "2.15.1") {
+  utils::globalVariables(c("nucleotides", ".I"))
+}
 #' Filter BOLD specimen + sequence data (output of bold_seqspec)
 #'
 #' Picks either shortest or longest sequences, for a given grouping variable


### PR DESCRIPTION
Added a call to `utils::globalVariables` so tests/checks don't make a note for the variables used with {data.table}.