### PR TITLE
added fix

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -96,6 +96,15 @@ b_read_xml <- function(x) {
 }
 b_read_tsv <- function(x, header = TRUE, sep = "\t",
                        cleanData = FALSE, ...) {
+  # -- fix for issue 104 ----------------------------------------
+  # wild '\n' characters in some fields
+  if (stringi::stri_detect_regex(x, "[^\r]\n[^\r]")) {
+    x_names <- stringi::stri_extract_first_regex(x, "^[^\r\n]+")
+    x_names <- stringi::stri_split_regex(x_names, "\t", simplify = TRUE)
+    pttrn <- paste0("(?<!", x_names[length(x_names)], "|\r)\n(?!=\r)")
+    x <- stringi::stri_replace_all_regex(x, pttrn, " ")   
+  }
+  # -------------------------------------------------------------
   x <- data.table::setDF(
     data.table::fread(
       text = x,

--- a/tests/testthat/test-bold_specimens.R
+++ b/tests/testthat/test-bold_specimens.R
@@ -43,5 +43,7 @@ test_that("bold_seq fails well", {
   expect_error(bold_specimens(geo = 'Costa Rica', timeout_ms = 2), "Timeout was reached")
 })
 
+# TODO: add test for 'Molgula manhattensis' (issue 104)
+
 # FIXME: The test wasn't doing that, removed it. Afaik, this function doesn't throw a warning for this.
 # test_that("Throws warning on call that takes forever including timeout in callopts", {})


### PR DESCRIPTION
## Description
added a check for wild `\n` in the response before parsing the data

## Related Issue
fix #104 and #105